### PR TITLE
Update for Factorio 2.0

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -16,4 +16,4 @@ tasks:
     dir: '{{.APPDATA}}\Factorio\Mods'
     cmds:
       # This command removes the symbolic link. WOOOOO
-      - unlink {{.MODNAME}}
+      - cmd /c rmdir {{.MODNAME}}

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,15 @@
 ---------------------------------------------------------------------------------------------------
+Version: 1.1.0
+Date: 21. 10. 2024
+  Minor Features:
+    - Updated default values to match Factorio 2.0.
+      - Cars & Tanks are now immune to cliff impacts by default.
+      - Fluid wagon capacity is now 50000.
+  Bugfixes:
+    - locomotive-max-speed (double) is no longer set to a string value by default (woops!).
+  Info:
+    - This update only get the mod up and running on base Factorio 2.0. There may be future updates to account for changes or new additions with the expansion.
+---------------------------------------------------------------------------------------------------
 Version: 1.0.1
 Date: 08. 06. 2024
   Major Features:

--- a/info.json
+++ b/info.json
@@ -1,9 +1,9 @@
    {
      "name": "ConfigurableVehicles",
-     "version": "1.0.1",
+     "version": "1.1.0",
      "title": "Configurable Vehicles",
      "author": "MrFastZombie",
-     "factorio_version": "1.1",
+     "factorio_version": "2.0",
 	 "description": "Lets you customize the properties of the vanilla vehicles.",
      "dependencies": ["? flattening-trains"]
    }

--- a/settings.lua
+++ b/settings.lua
@@ -18,7 +18,7 @@ data:extend({
         type = "bool-setting",
         name = "tank-cliff-impact",
         setting_type = "startup",
-        default_value = false,
+        default_value = true,
 		order = "bb"
     },
     {

--- a/settings.lua
+++ b/settings.lua
@@ -116,7 +116,7 @@ data:extend({
         type = "double-setting",
         name = "tank-turret-rotation-speed",
         setting_type = "startup",
-        default_value = 0.0058333333333333,
+        default_value = 0.00583333,
 		order = "bf"
     },
     {
@@ -166,7 +166,7 @@ data:extend({
         type = "bool-setting",
         name = "car-cliff-impact",
         setting_type = "startup",
-        default_value = false,
+        default_value = true,
 		order = "ab"
     },
     {
@@ -229,7 +229,7 @@ data:extend({
         type = "double-setting",
         name = "car-turret-rotation-speed",
         setting_type = "startup",
-        default_value = 0.0058333333333333,
+        default_value = 0.00583333,
 		order = "ac"
     },
     {
@@ -307,7 +307,7 @@ data:extend({
         type = "double-setting",
         name = "locomotive-max-speed",
         setting_type = "startup",
-        default_value = "1.2",
+        default_value = 1.2,
 		order = "czz"
     },
     {
@@ -428,7 +428,7 @@ data:extend({
         type = "int-setting",
         name = "fluid-wagon-capacity",
         setting_type = "startup",
-        default_value = 25000,
+        default_value = 50000,
 		order = "ezz"
     },
     {


### PR DESCRIPTION
Minor Features:
    - Updated default values to match Factorio 2.0.
      - Cars & Tanks are now immune to cliff impacts by default.
      - Fluid wagon capacity is now 50000.
  Bugfixes:
    - locomotive-max-speed (double) is no longer set to a string value by default (woops!).
  Info:
    - This update only get the mod up and running on base Factorio 2.0. There may be future updates to account for changes or new additions with the expansion.